### PR TITLE
SolidButton 아이콘 크기 및 간격 조정 #7

### DIFF
--- a/app/src/main/java/club/rooftop/demo/ui/buttons/ButtonScreen.kt
+++ b/app/src/main/java/club/rooftop/demo/ui/buttons/ButtonScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import club.rooftop.demo.R
 import club.rooftop.raus.common.VerticalSpacer
 import club.rooftop.raus.components.button.ButtonSize
 import club.rooftop.raus.components.button.SolidButton
@@ -32,6 +33,13 @@ fun ButtonScreen() {
         SolidButton(
             size = ButtonSize.S,
             text = "Small Button"
+        ) {}
+
+        VerticalSpacer(size = 8.dp)
+
+        SolidButton(
+            preVectorImgRes = R.drawable.ic_group,
+            text = "Button with Icon"
         ) {}
     }
 }

--- a/raus/src/main/java/club/rooftop/raus/components/button/SolidButton.kt
+++ b/raus/src/main/java/club/rooftop/raus/components/button/SolidButton.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -30,6 +31,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import club.rooftop.raus.R
 import club.rooftop.raus.common.HorizontalSpacer
 import club.rooftop.raus.foundation.color.Purple50
 import club.rooftop.raus.foundation.color.Purple60
@@ -71,10 +73,11 @@ fun SolidButton(
             Icon(
                 ImageVector.vectorResource(id = preVectorImgRes),
                 contentDescription = text,
+                modifier = Modifier.size(size.iconSize),
                 tint = contentColor
             )
 
-            HorizontalSpacer(size = 4.dp)
+            HorizontalSpacer(size = 2.dp)
         }
 
         Text(
@@ -85,29 +88,16 @@ fun SolidButton(
             style = if (size == ButtonSize.L) SubheadBold else Body1Bold
         )
     }
-
-//    Button(
-//        onClick = onClick,
-//        interactionSource = interactionSource,
-//        modifier = modifier
-//            .height(size.height)
-//            .clickable(indication = null, interactionSource = interactionSource) {},
-//        elevation = ButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp, 0.dp),
-//        shape = RoundedCornerShape(45.dp),
-//        colors = ButtonDefaults.buttonColors(backgroundColor = color, contentColor = contentColor),
-//        contentPadding = PaddingValues(horizontal = size.horizontalInnerPadding),
-//    ) {
-//
-//    }
 }
 
 enum class ButtonSize(
     val horizontalInnerPadding: Dp,
-    val height: Dp
+    val height: Dp,
+    val iconSize: Dp,
 ) {
-    L(16.dp, 52.dp),
-    M(16.dp, 40.dp),
-    S(10.dp, 34.dp),
+    L(16.dp, 52.dp, 28.dp),
+    M(16.dp, 40.dp, 20.dp),
+    S(10.dp, 34.dp, 20.dp),
 }
 
 enum class ButtonType {


### PR DESCRIPTION
SolidButton 앞 쪽에 붙는 prefix image의 크기 및 간격 조정합니다.

![image](https://user-images.githubusercontent.com/96655366/186036310-00cb534b-4653-4ea6-a418-c2f2517bc833.png)
